### PR TITLE
Update 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,5 +157,3 @@ The first release. Contains:
 - The purple paint fizzler version 14.
 - The portal condensation grid version 5.
 - The physics obliteration field version 11.
-
-Installation: Download the .zip, drop the .bee_packs into your packages folder, and enjoy!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
-## Version 1.7.2
+## Version 1.8
+The main package took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+The hybrid style took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+The hazard identification boards did not receive any changes (again).
+### Changelog
+- Fixed #11.
+- Fixed #5.
+- Fixed hybrid style's ceiling goo textures being set to use BTS yellow plastic textures.
+- Implemented #14.
+- Added a check if there's space for the camera above the entry/exit doors to spawn in the hybrid style.
+- Added hybrid-styled versions of asd417's HD pellet catchers.
+- Added on option to enable the Portal 1 color correction in the hybrid style.
+- Tweaked the metal tile variety in the hybrid style. The 4x4 textures will appear much less often on walls, and ceilings now use several textures, instead of only one.
+- Tweaked the lights in medium obs. rooms in the hybrid style.
+- Tweaked how heavy the gel flow will be when it's set to 'very heavy' on cube dropper gel droppers.
+- Tweaked the editor icons for the protruding autoportal, the angled autoportal, the unlinked autoportal, the cube hole, and Schrödinger's cubes.
+- Normal gel droppers will now use their P1-styled variants in the hybrid style.
+- Cleaned up some of the comments in the packages' files.
+- Removed several light entities from the large obs. room in the hybrid style.
+- Removed vertical entrances and exits from the hybrid style, they were broken.
+- Removed support for several cut fizzlers from the hybrid style in order to keep the files tidy.
+---
+# Version 1.7.2
 The main package took: 1 development version, with `Beta 1 Build 1 Release Candidate 1` being the one which got released.
 The hybrid style took: 6 development versions, with `Beta 2 Build 4 Release Candidate 1` being the one which got released.
 The hazard identification boards did not receive any changes (again).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Version 1.8
 The main package took: 9 development versions, with `Beta 1 Build 9 RC 2` being the one which got released.
 
-The hybrid style took: 7 development versions, with `Beta 4 Build 2 RC 3` being the one which got released.
+The hybrid style took: 8 development versions, with `Beta 4 Build 3 RC 4` being the one which got released.
 
 The hazard identification boards did not receive any changes (*yet* again).
 ### Changelog
@@ -17,6 +17,7 @@ The hazard identification boards did not receive any changes (*yet* again).
 - Tweaked how heavy the gel flow will be when it's set to 'very heavy' on cube dropper gel droppers.
 - Tweaked the editor icons for the protruding autoportal, the angled autoportal, the unlinked autoportal, the cube hole, and Schrödinger's cubes.
 - Normal gel droppers will now use their P1-styled variants in the hybrid style.
+- Normal permanent pellet catchers will now turn yellow when activated in the hybrid style.
 - Cleaned up some of the comments in the packages' files.
 - Removed several light entities from the large obs. room in the hybrid style.
 - Removed vertical entrances and exits from the hybrid style, they were broken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 1.8
+# Version 1.8
 The main package took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
 The hybrid style took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
 The hazard identification boards did not receive any changes (again).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version 1.8
 The main package took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+
 The hybrid style took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+
 The hazard identification boards did not receive any changes (again).
 ### Changelog
 - Fixed #11.
@@ -22,7 +24,9 @@ The hazard identification boards did not receive any changes (again).
 ---
 # Version 1.7.2
 The main package took: 1 development version, with `Beta 1 Build 1 Release Candidate 1` being the one which got released.
+
 The hybrid style took: 6 development versions, with `Beta 2 Build 4 Release Candidate 1` being the one which got released.
+
 The hazard identification boards did not receive any changes (again).
 ### Changelog
 - Added a new item: The cube hole. It is a hole that cubes and such can pass through, but the player can't.
@@ -46,7 +50,9 @@ The hazard identification boards did not receive any changes.
 ---
 # Version 1.7
 The main package took: 18 development versions, with `Beta 3 Build 5 Release Candidate 4` being the one which got released.
+
 The hazard identification boards took: 4 development versions, with `Beta 1 Build 4 Release Candidate 2` being the one which got released.
+
 The hybrid style took: 37 development versions, with `Beta 7 Build 11 Release Candidate 2` being the onw which got released.
 ### Changelog
 - Added a brand-new style: The hybrid style. It is a combination of Portal 1's and Portal 2's aesthetics, with some additional, minor changes. Heavily inspired by Zepalesque's *Portal: Enrichment* videos.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Version 1.8
-The main package took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+The main package took: 9 development versions, with `Beta 1 Build 9 RC 2` being the one which got released.
 
-The hybrid style took: [] development versions, with `Beta [] Build [] RC []` being the one which got released.
+The hybrid style took: 7 development versions, with `Beta 4 Build 2 RC 3` being the one which got released.
 
-The hazard identification boards did not receive any changes (again).
+The hazard identification boards did not receive any changes (*yet* again).
 ### Changelog
 - Fixed #11.
 - Fixed #5.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,7 +2,7 @@ Here, you can find everyone who has contributed to the packages in any way.
 
 **Areng** - Helped with the (now removed) physics obliteration field and the Reflection gel fixer.
 
-**TeamSpen210** - Helped with the (now removed) physics obliteration field, Schrödinger's cubes and the Reflection gel fixer. Made the paint fizzler, which I have repurposed as a base for my custom fizzlers.
+**TeamSpen210** - Helped with the (now removed) physics obliteration field, Schrödinger's cubes and the Reflection gel fixer. Made the paint fizzler, which I have repurposed as a base for my (now removed) custom fizzlers.
 
 **PieCreeper** - Created the cooperative cube fixer, which I used to find out how to make command-running items, like the (now removed) portal lights enabler. Made icons for the purple paint fizzler and Schrödinger's cubes.
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Changes the color of Reflection gel to be gray when splashed on surfaces and you
 *Hybrid style's preview image*
 ![hybrid_style_1](https://user-images.githubusercontent.com/125143965/235435706-d7532228-1b74-4292-944e-67f6d10d2f16.png)
 *Schrödinger's cubes*
-![schrodinger's_cubes](https://user-images.githubusercontent.com/125143965/235433342-4fff0be9-8e95-4355-9c35-562f04444b30.png)
+![schrodinger's_cubes_2](https://github.com/AxoLabs/BEE2-Axos-Packages/assets/125143965/2fba3a27-0423-44b7-8b16-3e61f2f71016)
 *Suspended panels*
 ![suspended_panels](https://user-images.githubusercontent.com/125143965/235435765-9598e6a9-588e-4260-8a25-b1b29f8b33d4.png)
 *Hybrid style in action, the map can be found [here](https://steamcommunity.com/sharedfiles/filedetails/?id=2961094236)*
 ![hybrid_style_2](https://user-images.githubusercontent.com/125143965/235436555-d9f7ef68-f394-46f6-b2d9-48bb184c639d.png)
-*Hybrid style's exit corridor 4#*
-![hybrid_style_4](https://user-images.githubusercontent.com/125143965/235436348-02d82d12-6b9f-4592-8985-22dfd66d75bf.png)
+*Hybrid style's exit corridor 3#*
+![hybrid_style_4_2](https://github.com/AxoLabs/BEE2-Axos-Packages/assets/125143965/2b57ac95-65df-4dbb-99cb-eafd82320850)
 *Stair variants*
 ![stair_variants](https://user-images.githubusercontent.com/125143965/235435948-5cadf695-c126-4ea1-a83b-29da3c0acefa.png)
 *Large glass panels*
@@ -84,4 +84,4 @@ Changes the color of Reflection gel to be gray when splashed on surfaces and you
 *Protruding autoportal, protruding surface, and a cube dropper gel dropper dropping a gel bomb*
 ![autoportals_and_gel_bombs](https://user-images.githubusercontent.com/125143965/235436211-0b3e0a82-2925-4031-aaf1-f0b87309592d.png)
 *An unnecessarily complicated setup of Schrödinger's cubes used to activate an unlinked autoportal*
-![schrodinger's_cubes_and_unlinked_autoportals](https://user-images.githubusercontent.com/125143965/235436489-838b4939-b813-49e8-bead-19f03c710845.png)
+![schrodinger's_cubes_and_unlinked_autoportals_2](https://github.com/AxoLabs/BEE2-Axos-Packages/assets/125143965/d944ff63-8452-416c-b7e5-0435af2826e0)


### PR DESCRIPTION
Update the README, the credits, and the changelog to keep the info in them up-to-date with version 1.8. The wiki will be updated shortly after.
- Update all the screenshots of Schrödinger's cubes.
- Update the changelog to include version 1.8.
- Update the screenshot of hybrid style's exit corridor 3#, it was severly out of date (still was named corridor 4#, the wall textures were outdated).